### PR TITLE
Add a nix flake providing wasixcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,46 @@ The installer will install wasixcc and its dependencies to `~/.wasixcc`
 
 </details>
 
+### Nix Flake
+
+This repository includes a `flake.nix` that provides a ready-to-use `wasixcc`
+toolchain with pinned:
+
+- custom WASIX LLVM (`wasix-org/llvm-project`)
+- Binaryen (`wasm-opt`)
+- WASIX sysroot (`sysroot`, `sysroot-eh`, `sysroot-ehpic`)
+
+Usage:
+
+```sh
+# Run wasixcc directly from the repo
+nix run github:wasix-org/wasixcc#wasixcc -- --version
+
+# Enter a shell with wasixcc on PATH from the repo
+nix develop github:wasix-org/wasixcc
+wasixcc --version
+```
+
+Current flake support: `x86_64-linux`.
+
+#### Updating pinned LLVM hashes
+
+When updating the pinned WASIX LLVM release in `flake.nix`, update both the
+versioned URL and the `hash` value.
+
+Example workflow:
+
+```sh
+# 1) Check latest LLVM release tag
+curl -fsSL https://api.github.com/repos/wasix-org/llvm-project/releases/latest | jq -r .tag_name
+
+# 2) Prefetch the x86_64 Linux archive to get the Nix hash
+nix store prefetch-file --json \
+  https://github.com/wasix-org/llvm-project/releases/download/<TAG>/LLVM-Linux-x86_64.tar.gz
+
+# 3) Copy the returned "hash" into flake.nix and update the URL/tag there
+```
+
 ### GitHub Actions
 
 To use `wasixcc` in your GitHub Action use the following snippet

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771008912,
+        "narHash": "sha256-gf2AmWVTs8lEq7z/3ZAsgnZDhWIckkb+ZnAo5RzSxJg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a82ccc39b39b621151d6732718e3e250109076fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,202 @@
+{
+  description = "wasixcc with pinned WASIX LLVM, Binaryen, and sysroot";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        lib = pkgs.lib;
+
+        cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+        version = cargoToml.package.version;
+
+        isLinux = pkgs.stdenv.hostPlatform.isLinux;
+        supported = isLinux && pkgs.stdenv.hostPlatform.isx86_64;
+
+        llvmSrcForSystem =
+          if system == "x86_64-linux" then
+            pkgs.fetchurl {
+              url = "https://github.com/wasix-org/llvm-project/releases/download/21.1.203/LLVM-Linux-x86_64.tar.gz";
+              hash = "sha256-PY/diViHY2ua/Y1jcTUiyTlDARp+J0vwDsB18Rggr5Y=";
+            }
+          else
+            throw "Unsupported system for pinned WASIX LLVM: ${system}";
+
+        binaryenSrcForSystem =
+          if system == "x86_64-linux" then
+            pkgs.fetchurl {
+              url = "https://github.com/WebAssembly/binaryen/releases/download/version_126/binaryen-version_126-x86_64-linux.tar.gz";
+              hash = "sha256-5Ifg6sHwKmc5gWxhcnCwM+XT+MqQQ5MB/QKGRgMi/XY=";
+            }
+          else
+            throw "Unsupported system for pinned Binaryen: ${system}";
+
+        wasixLlvm = pkgs.stdenvNoCC.mkDerivation {
+          pname = "wasix-llvm";
+          version = "21.1.203";
+          src = llvmSrcForSystem;
+
+          dontUnpack = true;
+          nativeBuildInputs = [ pkgs.gnutar ] ++ lib.optionals isLinux [ pkgs.autoPatchelfHook ];
+          buildInputs = lib.optionals isLinux [ pkgs.stdenv.cc.cc.lib ];
+
+          installPhase = ''
+            runHook preInstall
+            mkdir -p "$out"
+            tar -xzf "$src" -C "$out"
+            chmod -R u+w "$out"
+            runHook postInstall
+          '';
+        };
+
+        binaryen = pkgs.stdenvNoCC.mkDerivation {
+          pname = "binaryen";
+          version = "126";
+          src = binaryenSrcForSystem;
+
+          dontUnpack = true;
+          nativeBuildInputs = [ pkgs.gnutar ] ++ lib.optionals isLinux [ pkgs.autoPatchelfHook ];
+          buildInputs = lib.optionals isLinux [ pkgs.stdenv.cc.cc.lib ];
+
+          installPhase = ''
+            runHook preInstall
+            mkdir -p "$out"
+            tmp="$(mktemp -d)"
+            tar -xzf "$src" -C "$tmp"
+            cp -a "$tmp"/binaryen-version_126/. "$out"/
+            chmod -R u+w "$out"
+            runHook postInstall
+          '';
+        };
+
+        wasixSysroot = pkgs.stdenvNoCC.mkDerivation {
+          pname = "wasix-sysroot";
+          version = "v2026-02-16.1";
+
+          srcSysroot = pkgs.fetchurl {
+            url = "https://github.com/wasix-org/wasix-libc/releases/download/v2026-02-16.1/sysroot.tar.gz";
+            hash = "sha256-IUvuFhdPtPOUQU5knEXE+xwgWVmSCz7LiJ4VlzAjf+0=";
+          };
+          srcSysrootEh = pkgs.fetchurl {
+            url = "https://github.com/wasix-org/wasix-libc/releases/download/v2026-02-16.1/sysroot-eh.tar.gz";
+            hash = "sha256-0avggow76g1qp79SWjN6XbbWCK3P1A69kSYT0bWfkFQ=";
+          };
+          srcSysrootEhpic = pkgs.fetchurl {
+            url = "https://github.com/wasix-org/wasix-libc/releases/download/v2026-02-16.1/sysroot-ehpic.tar.gz";
+            hash = "sha256-6exFF8vtpUdK+tN0QFw0oZTNbRUMImZzd92g+8YfPgg=";
+          };
+
+          dontUnpack = true;
+          nativeBuildInputs = [ pkgs.gnutar ];
+
+          installPhase = ''
+            runHook preInstall
+            mkdir -p "$out"
+
+            unpack_sysroot() {
+              local archive="$1"
+              local target="$2"
+              local tmp
+              tmp="$(mktemp -d)"
+
+              tar -xzf "$archive" -C "$tmp"
+              local extracted
+              extracted="$(find "$tmp" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+
+              mkdir -p "$out/$target"
+              cp -a "$extracted/sysroot/." "$out/$target/"
+            }
+
+            unpack_sysroot "$srcSysroot" "sysroot"
+            unpack_sysroot "$srcSysrootEh" "sysroot-eh"
+            unpack_sysroot "$srcSysrootEhpic" "sysroot-ehpic"
+            runHook postInstall
+          '';
+        };
+
+        wasixccRaw = pkgs.rustPlatform.buildRustPackage {
+          pname = "wasixcc-raw";
+          inherit version;
+          src = ./.;
+          cargoLock.lockFile = ./Cargo.lock;
+
+          doCheck = true;
+
+          installPhase = ''
+            runHook preInstall
+            mkdir -p "$out/libexec"
+            cp "$(find target -type f -path '*/release/wasixccenv' | head -n 1)" "$out/libexec/wasixccenv"
+            runHook postInstall
+          '';
+        };
+
+        wasixcc =
+          if supported then
+            pkgs.stdenvNoCC.mkDerivation {
+              pname = "wasixcc";
+              inherit version;
+              dontUnpack = true;
+
+              installPhase = ''
+                runHook preInstall
+                mkdir -p "$out/bin" "$out/libexec"
+
+                cp "${wasixccRaw}/libexec/wasixccenv" "$out/libexec/wasixccenv"
+
+                for cmd in wasixcc 'wasix++' wasixcc++ wasixar wasixnm wasixranlib wasixld wasixccenv; do
+                  printf '%s\n' \
+                    '#!${pkgs.bash}/bin/bash' \
+                    'set -euo pipefail' \
+                    'export WASIXCC_LLVM_LOCATION="${wasixLlvm}"' \
+                    'export WASIXCC_BINARYEN_LOCATION="${binaryen}"' \
+                    'export WASIXCC_SYSROOT_PREFIX="${wasixSysroot}"' \
+                    "exec -a \"\$0\" \"$out/libexec/wasixccenv\" \"\$@\"" \
+                    > "$out/bin/$cmd"
+                  chmod +x "$out/bin/$cmd"
+                done
+
+                runHook postInstall
+              '';
+            }
+          else
+            throw "wasixcc flake package currently supports only x86_64-linux; current system is ${system}";
+      in
+      {
+        packages = {
+          default = wasixcc;
+          inherit
+            wasixcc
+            wasixLlvm
+            binaryen
+            wasixSysroot
+            ;
+        };
+
+        apps = {
+          default = flake-utils.lib.mkApp {
+            drv = wasixcc;
+            name = "wasixcc";
+          };
+          wasixcc = flake-utils.lib.mkApp {
+            drv = wasixcc;
+            name = "wasixcc";
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = [ wasixcc ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
Note: this is currently a bit hacky because it just pins the llvm build
hashes and patches them to avoid re-building LLVM, but that's the
practicaly approach, and it works.
