### PR TITLE
feat: enable wide-arithmetic WebAssembly extension by default

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -26,9 +26,7 @@ static WASM_OPT_ENABLED_FEATURES: &[&str] = &[
     "--enable-simd",
     "--enable-relaxed-simd",
     "--enable-extended-const",
-    // Unsupported by wasm-opt right now:
-    // https://github.com/WebAssembly/binaryen/issues/8544
-    // "--enable-wide-arithmetic",
+    "--enable-wide-arithmetic",
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/compiler/flags.rs
+++ b/src/compiler/flags.rs
@@ -65,9 +65,7 @@ static DEFAULT_WASM_CLANG_FLAGS: &[&str] = &[
     "-msimd128",
     "-mrelaxed-simd",
     "-mextended-const",
-    // Unsupported by wasm-opt right now:
-    // https://github.com/WebAssembly/binaryen/issues/8544
-    // "-mwide-arithmetic",
+    "-mwide-arithmetic",
 ];
 
 // We always specify values for these flags according to the build configuration, so
@@ -559,6 +557,7 @@ mod tests {
                 "-msimd128".to_string(),
                 "-mrelaxed-simd".to_string(),
                 "-mextended-const".to_string(),
+                "-mwide-arithmetic".to_string(),
                 "-O2".to_string(),
             ]
         );
@@ -637,6 +636,7 @@ mod tests {
                 "-msimd128".to_string(),
                 "-mrelaxed-simd".to_string(),
                 "-mextended-const".to_string(),
+                "-mwide-arithmetic".to_string(),
                 "-O2".to_string(),
                 "-g0".to_string(),
             ]
@@ -708,6 +708,7 @@ mod tests {
             "-mno-simd128".to_string(),
             "-mno-relaxed-simd".to_string(),
             "-mno-extended-const".to_string(),
+            "-mno-wide-arithmetic".to_string(),
             "test.c".to_string(),
         ];
         let (pa, _) = prepare_compiler_args(args, &mut us, false).unwrap();
@@ -718,9 +719,11 @@ mod tests {
                 "-msimd128".to_string(),
                 "-mrelaxed-simd".to_string(),
                 "-mextended-const".to_string(),
+                "-mwide-arithmetic".to_string(),
                 "-mno-simd128".to_string(),
                 "-mno-relaxed-simd".to_string(),
                 "-mno-extended-const".to_string(),
+                "-mno-wide-arithmetic".to_string(),
             ]
         );
     }


### PR DESCRIPTION
Follow-up of #60, we were waiting for a new release of binaryen that would support the WebAssembly extension.