### PR TITLE
fix(download-llvm): support tags without 'v' or 'version_' prefix

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -97,11 +97,14 @@ impl FromStr for TagSpec {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s == "latest" {
             Ok(TagSpec::Latest)
-        } else if s.starts_with('v') || s.starts_with("version_") {
+        } else if s.starts_with('v')
+            || s.starts_with("version_")
+            || s.starts_with(|c: char| c.is_ascii_digit())
+        {
             Ok(TagSpec::Tag(s.to_string()))
         } else {
             bail!(
-                "Invalid tag specification: `{s}`. Use 'latest', a tag starting with 'v', or 'version_XXX'."
+                "Invalid tag specification: `{s}`. Use 'latest', a tag starting with 'v', 'version_XXX', or a numeric version."
             );
         }
     }


### PR DESCRIPTION
The llvm-project releases are not prefixed with 'v' or 'version' and so we need to relax the check:
```
❯ wasixccenv download-llvm 21.1.204
error: invalid value '21.1.204' for '[TAG]': Invalid tag specification: `21.1.204`. Use 'latest', a tag starting with 'v', or 'version_XXX'.
``

https://github.com/wasix-org/llvm-project/releases