### PR TITLE
ignore some versioning-related params for wasm-ld

### DIFF
--- a/src/compiler/flags.rs
+++ b/src/compiler/flags.rs
@@ -153,6 +153,8 @@ static WASM_LD_FLAGS_TO_DISCARD: LazyLock<HashSet<&str>> = LazyLock::new(|| {
         "--allow-shlib-undefined",
         "--enable-new-dtags",
         "--version-script",
+        "--no-undefined-version", // wasm-ld has no symbol versioning
+        "--undefined-version",    // wasm-ld has no symbol versioning
         "--stats",
         "--no-stats",
     ]


### PR DESCRIPTION
These aren't supported with wasm-ld, breaking some builds that set them