### PR TITLE
fix: explicitly pin linker to absolute path

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -135,8 +135,14 @@ pub(crate) fn run(args: Vec<String>, mut user_settings: UserSettings, run_cxx: b
         } else {
             "clang"
         }));
+        let user_set_linker = original_args.iter().any(|a| a.starts_with("-fuse-ld"));
         command.args(original_args);
         command.args([OsStr::new("--target=wasm32-wasi")]);
+        if !user_set_linker {
+            let mut fuse_ld = OsString::from("-fuse-ld=");
+            fuse_ld.push(user_settings.llvm_location.get_tool_path("wasm-ld"));
+            command.arg(fuse_ld);
+        }
         return run_command(command);
     }
 


### PR DESCRIPTION
Pin the linker by absolute path. With no inputs we hand the args straight to clang, which includes driver probes that *link* (notably meson's linker detection: `clang -Wl,--version`). clang otherwise spawns a bare `wasm-ld` resolved off $PATH, which a sanitized build env (eg. meson's compiler checks) doesn't carry, so the probe fails with "Unable to detect linker".