### PR TITLE
fix: link the C++ runtime into C++ shared libraries

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -487,6 +487,21 @@ fn link_inputs(state: &State) -> Result<()> {
         }
     }
 
+    // A C++ shared library (e.g. a CPython extension module) may be loaded by a host
+    // that doesn't export the C++ runtime -- the CPython interpreter is plain C -- so
+    // its libc++/libc++abi references would otherwise be left as unresolved dynamic
+    // imports (SharedLibrary sets --unresolved-symbols=import-dynamic below) and fail
+    // at load. Link the runtime into the module instead. Only SharedLibrary reaches
+    // here; executables get the C++ runtime in the block above. wasm-ld extracts
+    // archive members lazily regardless of command-line order, so only the referenced
+    // members are pulled in.
+    if !module_kind.is_executable() && (state.cxx || state.user_settings.include_cpp_symbols) {
+        command.args(["-lc++", "-lc++abi"]);
+        if state.user_settings.wasm_exceptions.is_enabled() {
+            command.arg("-lunwind");
+        }
+    }
+
     if matches!(module_kind, ModuleKind::DynamicMain) {
         command.args(["--no-whole-archive"]);
     }


### PR DESCRIPTION

A C++ shared library (`ModuleKind::SharedLibrary`) — e.g. a CPython extension module — may be `dlopen`'d by a host that does not export the C++ runtime. The CPython interpreter itself is plain C, so `libc++`/`libc++abi` symbols the extension references (e.g. `std::bad_array_new_length`'s dtor) aren't provided by the main module. Because shared libraries link with `--unresolved-symbols=import-dynamic`, those symbols are emitted as dynamic imports and fail to resolve at load time.

To fix this, we forcefully link in C++ symbols for shared libraries.
