### PR TITLE
fix: preserve link order

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -100,13 +100,68 @@ pub(crate) struct BuildSettings {
     use_wasm_opt: bool,
 }
 
+/// A single user-supplied token destined for the link stage. Flags (`-Wl`,
+/// `-Xlinker`, forwarded `-L`/`-l`, ...) and file inputs (`.o`/`.a`/...) share
+/// one ordered stream so their original left-to-right order survives: e.g.
+/// `--whole-archive foo.a --no-whole-archive` must stay contiguous, otherwise
+/// the bracket wraps nothing and `foo.a` is linked lazily outside it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum LinkToken {
+    Flag(String),
+    Input(PathBuf),
+}
+
 #[derive(Debug)]
 pub(crate) struct PreparedArgs {
     compiler_args: Vec<String>,
-    linker_args: Vec<String>,
+    // User link-stage tokens in original order. wasixcc's own injected flags and
+    // sysroot libs are added separately in `link_inputs`.
+    link_args: Vec<LinkToken>,
     compiler_inputs: Vec<PathBuf>,
-    linker_inputs: Vec<PathBuf>,
     output: Option<PathBuf>,
+}
+
+impl PreparedArgs {
+    fn has_linker_inputs(&self) -> bool {
+        self.link_args
+            .iter()
+            .any(|token| matches!(token, LinkToken::Input(_)))
+    }
+
+    #[cfg(test)]
+    fn linker_flags(&self) -> Vec<String> {
+        self.link_args
+            .iter()
+            .filter_map(|token| match token {
+                LinkToken::Flag(flag) => Some(flag.clone()),
+                LinkToken::Input(_) => None,
+            })
+            .collect()
+    }
+
+    #[cfg(test)]
+    fn linker_inputs(&self) -> Vec<PathBuf> {
+        self.link_args
+            .iter()
+            .filter_map(|token| match token {
+                LinkToken::Input(input) => Some(input.clone()),
+                LinkToken::Flag(_) => None,
+            })
+            .collect()
+    }
+
+    // The ordered user link stream as `link_inputs` emits it to wasm-ld (flags
+    // and inputs interleaved), for asserting relative order in tests.
+    #[cfg(test)]
+    fn link_stream(&self) -> Vec<String> {
+        self.link_args
+            .iter()
+            .map(|token| match token {
+                LinkToken::Flag(flag) => flag.clone(),
+                LinkToken::Input(input) => input.to_string_lossy().into_owned(),
+            })
+            .collect()
+    }
 }
 
 #[derive(Debug)]
@@ -127,7 +182,7 @@ pub(crate) fn run(args: Vec<String>, mut user_settings: UserSettings, run_cxx: b
     tracing::debug!("Build settings: {build_settings:?}");
     tracing::debug!("Compiler/linker args: {args:?}");
 
-    if args.compiler_inputs.is_empty() && args.linker_inputs.is_empty() {
+    if args.compiler_inputs.is_empty() && !args.has_linker_inputs() {
         // If there are no inputs, just pass everything through to clang.
         // This lets us support invocations such as `wasixcc -dumpmachine`.
         let mut command = Command::new(user_settings.llvm_location.get_tool_path(if run_cxx {
@@ -196,7 +251,7 @@ pub(crate) fn link_only(args: Vec<String>, mut user_settings: UserSettings) -> R
     tracing::debug!("User settings: {user_settings:?}");
     tracing::debug!("Linker args: {args:?}");
 
-    if args.linker_inputs.is_empty() {
+    if !args.has_linker_inputs() {
         // If there are no inputs, just pass everything through to wasm-ld.
         let mut command = Command::new(user_settings.llvm_location.get_tool_path("wasm-ld"));
         command.args(original_args);
@@ -369,7 +424,9 @@ fn compile_inputs(state: &mut State) -> Result<()> {
             };
 
             command.arg("-o").arg(&output_path);
-            state.args.linker_inputs.push(output_path);
+            // Compiled objects follow the user link tokens, matching the prior
+            // behaviour where they were appended after user inputs.
+            state.args.link_args.push(LinkToken::Input(output_path));
 
             run_command(command)?;
         }
@@ -400,144 +457,167 @@ fn link_inputs(state: &State) -> Result<()> {
     let sysroot_lib_path = sysroot_path.join("lib");
     let sysroot_lib_wasm32_path = sysroot_lib_path.join("wasm32-wasi");
 
+    let args = build_link_args(state, &sysroot_lib_path, &sysroot_lib_wasm32_path)?;
+
     let mut command = Command::new(linker_path);
+    command.args(args);
 
-    command.args(&state.args.linker_args);
+    run_command(command)
+}
 
-    command.args([
-        "--extra-features=atomics",
-        "--extra-features=bulk-memory",
-        "--extra-features=mutable-globals",
-        "--shared-memory",
-        "--max-memory=4294967296", // TODO: make configurable
-        "--import-memory",
-        "--export-dynamic",
-        "--export=__wasm_call_ctors",
-        // Do not demangle the function names (happens by default)
-        "--no-demangle",
-    ]);
+// Assemble the full wasm-ld argument vector (everything after the tool name).
+// Kept separate from spawning so the ordering can be unit-tested.
+fn build_link_args(
+    state: &State,
+    sysroot_lib_path: &Path,
+    sysroot_lib_wasm32_path: &Path,
+) -> Result<Vec<OsString>> {
+    let module_kind = state.user_settings.module_kind();
+    let mut args: Vec<OsString> = Vec::new();
+
+    let mut push = |arg: &str| args.push(OsString::from(arg));
+
+    push("--extra-features=atomics");
+    push("--extra-features=bulk-memory");
+    push("--extra-features=mutable-globals");
+    push("--shared-memory");
+    push("--max-memory=4294967296"); // TODO: make configurable
+    push("--import-memory");
+    push("--export-dynamic");
+    push("--export=__wasm_call_ctors");
+    // Do not demangle the function names (happens by default)
+    push("--no-demangle");
 
     if state.user_settings.wasm_exceptions.is_enabled() {
-        command.args(["-mllvm", "--wasm-enable-eh"]);
-        command.args(["-mllvm", "--wasm-enable-sjlj"]);
+        push("-mllvm");
+        push("--wasm-enable-eh");
+        push("-mllvm");
+        push("--wasm-enable-sjlj");
 
         if state.user_settings.wasm_exceptions.is_legacy() {
-            command.args(["-mllvm", "--wasm-use-legacy-eh=true"]);
+            push("-mllvm");
+            push("--wasm-use-legacy-eh=true");
         } else {
-            command.args(["-mllvm", "--wasm-use-legacy-eh=false"]);
+            push("-mllvm");
+            push("--wasm-use-legacy-eh=false");
         }
 
         // Use native wasm exceptions
-        command.args(["-mllvm", "--exception-model=wasm"]);
+        push("-mllvm");
+        push("--exception-model=wasm");
     }
 
-    let module_kind = state.user_settings.module_kind();
-
-    command.args([
-        "--export=__wasm_init_tls",
-        "--export=__wasm_signal",
-        "--export=__tls_size",
-        "--export=__tls_align",
-        "--export=__tls_base",
-        "--export-if-defined=__indirect_function_table", // needed for reflection and call_dynamic
-    ]);
+    push("--export=__wasm_init_tls");
+    push("--export=__wasm_signal");
+    push("--export=__tls_size");
+    push("--export=__tls_align");
+    push("--export=__tls_base");
+    push("--export-if-defined=__indirect_function_table"); // needed for reflection and call_dynamic
 
     if module_kind.is_executable() {
-        command.args([
-            "--export-if-defined=__stack_pointer",
-            "--export-if-defined=__heap_base",
-            "--export-if-defined=__data_end",
-        ]);
+        push("--export-if-defined=__stack_pointer");
+        push("--export-if-defined=__heap_base");
+        push("--export-if-defined=__data_end");
     }
 
     if matches!(module_kind, ModuleKind::DynamicMain) {
-        command.args(["--whole-archive", "--export-all"]);
+        push("--whole-archive");
+        push("--export-all");
     }
 
     // Make sysroots libs available to all modules so they can optionally
     // link against them if needed, even when we don't.
     let mut lib_arg = OsString::new();
     lib_arg.push("-L");
-    lib_arg.push(&sysroot_lib_path);
-    command.arg(lib_arg);
+    lib_arg.push(sysroot_lib_path);
+    args.push(lib_arg);
 
     let mut lib_arg = OsString::new();
     lib_arg.push("-L");
-    lib_arg.push(&sysroot_lib_wasm32_path);
-    command.arg(lib_arg);
+    lib_arg.push(sysroot_lib_wasm32_path);
+    args.push(lib_arg);
+
+    let mut push = |arg: &str| args.push(OsString::from(arg));
 
     if module_kind.is_executable() {
-        command.args([
-            "-lwasi-emulated-getpid",
-            "-lwasi-emulated-mman",
-            "-lwasi-emulated-process-clocks",
-            "-lc",
-            "-lresolv",
-            "-lrt",
-            "-lm",
-            "-lpthread",
-            "-lutil",
-        ]);
+        push("-lwasi-emulated-getpid");
+        push("-lwasi-emulated-mman");
+        push("-lwasi-emulated-process-clocks");
+        push("-lc");
+        push("-lresolv");
+        push("-lrt");
+        push("-lm");
+        push("-lpthread");
+        push("-lutil");
 
         if state.cxx || state.user_settings.include_cpp_symbols {
-            command.args(["-lc++", "-lc++abi"]);
+            push("-lc++");
+            push("-lc++abi");
             if state.user_settings.wasm_exceptions.is_enabled() {
-                command.arg("-lunwind");
+                push("-lunwind");
             }
         }
     }
 
     if matches!(module_kind, ModuleKind::DynamicMain) {
-        command.args(["--no-whole-archive"]);
+        push("--no-whole-archive");
     }
 
     // Link as much as needed out of libclang_rt.builtins regardless of module kind.
-    command.arg("-lclang_rt.builtins-wasm32");
+    push("-lclang_rt.builtins-wasm32");
 
-    if state.user_settings.module_kind().requires_pic() {
-        command.args([
-            "--experimental-pic",
-            "--export-if-defined=__wasm_apply_data_relocs",
-            "--export-if-defined=__wasm_apply_tls_relocs",
-        ]);
+    if module_kind.requires_pic() {
+        push("--experimental-pic");
+        push("--export-if-defined=__wasm_apply_data_relocs");
+        push("--export-if-defined=__wasm_apply_tls_relocs");
     }
 
     match module_kind {
         ModuleKind::StaticMain => {
             // TODO: make configurable
-            command.args(["-z", "stack-size=8388608"]);
+            push("-z");
+            push("stack-size=8388608");
         }
 
         ModuleKind::DynamicMain => {
-            command.args(["-pie", "-lcommon-tag-stubs"]);
+            push("-pie");
+            push("-lcommon-tag-stubs");
         }
 
         ModuleKind::SharedLibrary => {
-            command.args([
-                "-shared",
-                "--no-entry",
-                "--unresolved-symbols=import-dynamic",
-            ]);
+            push("-shared");
+            push("--no-entry");
+            push("--unresolved-symbols=import-dynamic");
             if state.user_settings.link_symbolic {
-                command.arg("-Bsymbolic");
+                push("-Bsymbolic");
             }
         }
 
         ModuleKind::ObjectFile => panic!("Internal error: object files can't be linked"),
     }
 
-    command.args(&state.args.linker_inputs);
-
-    if module_kind.is_executable() {
-        command.arg(sysroot_lib_wasm32_path.join("crt1.o"));
-    } else {
-        command.arg(sysroot_lib_wasm32_path.join("scrt1.o"));
+    // User link tokens as one ordered stream, so --whole-archive/--no-whole-archive
+    // pairs keep their archive bracketed. Placed after the DynamicMain whole-archive
+    // block: a trailing user -l for a lib that block already force-included would
+    // otherwise re-pull it and produce a duplicate-symbol error. Lazy resolution
+    // still binds user objects to the sysroot -lc above.
+    for token in &state.args.link_args {
+        match token {
+            LinkToken::Flag(flag) => args.push(OsString::from(flag)),
+            LinkToken::Input(input) => args.push(input.clone().into_os_string()),
+        }
     }
 
-    command.arg("-o");
-    command.arg(output_path(state)?);
+    if module_kind.is_executable() {
+        args.push(sysroot_lib_wasm32_path.join("crt1.o").into_os_string());
+    } else {
+        args.push(sysroot_lib_wasm32_path.join("scrt1.o").into_os_string());
+    }
 
-    run_command(command)
+    args.push(OsString::from("-o"));
+    args.push(output_path(state)?.into_os_string());
+
+    Ok(args)
 }
 
 fn run_wasm_opt(state: &State) -> Result<()> {
@@ -799,9 +879,8 @@ mod tests {
             },
             args: PreparedArgs {
                 compiler_args: Vec::new(),
-                linker_args: Vec::new(),
+                link_args: Vec::new(),
                 compiler_inputs: Vec::new(),
-                linker_inputs: Vec::new(),
                 output: Some(PathBuf::from("test_output")),
             },
             cxx: false,
@@ -827,9 +906,8 @@ mod tests {
             },
             args: PreparedArgs {
                 compiler_args: Vec::new(),
-                linker_args: Vec::new(),
+                link_args: Vec::new(),
                 compiler_inputs: Vec::new(),
-                linker_inputs: Vec::new(),
                 output: Some(PathBuf::from("myprogram")),
             },
             cxx: false,
@@ -855,9 +933,8 @@ mod tests {
             },
             args: PreparedArgs {
                 compiler_args: Vec::new(),
-                linker_args: Vec::new(),
+                link_args: Vec::new(),
                 compiler_inputs: Vec::new(),
-                linker_inputs: Vec::new(),
                 output: Some(PathBuf::from("myprogram.wasm")),
             },
             cxx: false,
@@ -884,9 +961,8 @@ mod tests {
             },
             args: PreparedArgs {
                 compiler_args: Vec::new(),
-                linker_args: Vec::new(),
+                link_args: Vec::new(),
                 compiler_inputs: Vec::new(),
-                linker_inputs: Vec::new(),
                 output: None,
             },
             cxx: false,
@@ -912,9 +988,8 @@ mod tests {
             },
             args: PreparedArgs {
                 compiler_args: Vec::new(),
-                linker_args: Vec::new(),
+                link_args: Vec::new(),
                 compiler_inputs: Vec::new(),
-                linker_inputs: Vec::new(),
                 output: Some(PathBuf::from("myprogram")),
             },
             cxx: false,
@@ -941,9 +1016,8 @@ mod tests {
             },
             args: PreparedArgs {
                 compiler_args: Vec::new(),
-                linker_args: Vec::new(),
+                link_args: Vec::new(),
                 compiler_inputs: Vec::new(),
-                linker_inputs: Vec::new(),
                 output: Some(PathBuf::from("/path/to/output")),
             },
             cxx: false,
@@ -970,9 +1044,8 @@ mod tests {
             },
             args: PreparedArgs {
                 compiler_args: Vec::new(),
-                linker_args: Vec::new(),
+                link_args: Vec::new(),
                 compiler_inputs: Vec::new(),
-                linker_inputs: Vec::new(),
                 output: Some(PathBuf::from("myprogram.wasm")),
             },
             cxx: false,
@@ -1002,9 +1075,8 @@ mod tests {
             },
             args: PreparedArgs {
                 compiler_args: Vec::new(),
-                linker_args: Vec::new(),
+                link_args: Vec::new(),
                 compiler_inputs: Vec::new(),
-                linker_inputs: Vec::new(),
                 output: Some(output_path.clone()),
             },
             cxx: false,
@@ -1064,9 +1136,8 @@ mod tests {
             },
             args: PreparedArgs {
                 compiler_args: Vec::new(),
-                linker_args: Vec::new(),
+                link_args: Vec::new(),
                 compiler_inputs: Vec::new(),
-                linker_inputs: Vec::new(),
                 output: Some(output_path.clone()),
             },
             cxx: false,
@@ -1132,7 +1203,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            prepared.linker_args,
+            prepared.linker_flags(),
             vec![
                 "-lmylib".to_string(),
                 "--version-script,/path/to/script".to_string(),
@@ -1142,6 +1213,100 @@ mod tests {
         assert_eq!(
             prepared.output,
             Some(PathBuf::from("--version-script=foo.txt"))
+        );
+    }
+
+    fn link_args_state(module_kind: ModuleKind, link_args: Vec<LinkToken>) -> State {
+        let us = UserSettings {
+            module_kind: Some(module_kind),
+            ..Default::default()
+        };
+        State {
+            user_settings: us,
+            build_settings: BuildSettings {
+                opt_level: OptLevel::O0,
+                debug_level: DebugLevel::G0,
+                use_wasm_opt: false,
+            },
+            args: PreparedArgs {
+                compiler_args: Vec::new(),
+                link_args,
+                compiler_inputs: Vec::new(),
+                output: Some(PathBuf::from("out.wasm")),
+            },
+            cxx: false,
+            temp_dir: PathBuf::from("/tmp"),
+        }
+    }
+
+    fn rendered_link_args(state: &State) -> Vec<String> {
+        // Arbitrary sysroot paths; build_link_args does not touch the filesystem.
+        build_link_args(
+            state,
+            Path::new("/sysroot/lib"),
+            Path::new("/sysroot/lib/wasm32-wasi"),
+        )
+        .unwrap()
+        .iter()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect()
+    }
+
+    #[test]
+    fn test_dynamic_main_user_lib_emitted_after_whole_archive_block() {
+        // Regression: for DynamicMain, wasixcc force-includes the sysroot libs via
+        // its own --whole-archive block. A user -l naming the same archive must be
+        // emitted AFTER --no-whole-archive, otherwise (with a referencing object
+        // ahead of it) it lazily pulls a member the block also force-pulls, and
+        // wasm-ld reports a duplicate symbol.
+        let state = link_args_state(
+            ModuleKind::DynamicMain,
+            vec![
+                LinkToken::Input(PathBuf::from("main.o")),
+                LinkToken::Flag("-lwasi-emulated-process-clocks".to_string()),
+            ],
+        );
+        let args = rendered_link_args(&state);
+
+        let nwa = args
+            .iter()
+            .position(|a| a == "--no-whole-archive")
+            .expect("DynamicMain must close its whole-archive block");
+        // wasixcc still injects its own copy inside the block.
+        let injected = args
+            .iter()
+            .position(|a| a == "-lwasi-emulated-process-clocks")
+            .unwrap();
+        let user = args
+            .iter()
+            .rposition(|a| a == "-lwasi-emulated-process-clocks")
+            .unwrap();
+        assert!(injected < nwa, "injected lib should sit inside the block");
+        assert!(
+            user > nwa,
+            "user -l must follow --no-whole-archive, got {args:?}"
+        );
+    }
+
+    #[test]
+    fn test_user_whole_archive_bracket_contiguous_in_link_args() {
+        // A user --whole-archive <archive> --no-whole-archive must reach wasm-ld
+        // contiguous so the archive is bracketed. wasixcc injects no whole-archive
+        // block for SharedLibrary, so nothing splits the stream.
+        let state = link_args_state(
+            ModuleKind::SharedLibrary,
+            vec![
+                LinkToken::Flag("--whole-archive".to_string()),
+                LinkToken::Input(PathBuf::from("libtest.a")),
+                LinkToken::Flag("--no-whole-archive".to_string()),
+            ],
+        );
+        let args = rendered_link_args(&state);
+
+        let wa = args.iter().position(|a| a == "--whole-archive").unwrap();
+        assert_eq!(
+            &args[wa..wa + 3],
+            &["--whole-archive", "libtest.a", "--no-whole-archive"]
         );
     }
 }

--- a/src/compiler/flags.rs
+++ b/src/compiler/flags.rs
@@ -1,13 +1,17 @@
 use crate::{
     args::UserSettings,
     compiler::{
-        BuildSettings, DebugLevel, ModuleKind, OptLevel, PreparedArgs, WasmExceptionStyle,
-        response_file,
+        BuildSettings, DebugLevel, LinkToken, ModuleKind, OptLevel, PreparedArgs,
+        WasmExceptionStyle, response_file,
     },
 };
 use anyhow::Result;
 use lexer::{Flag, lex_args};
-use std::{collections::HashSet, path::PathBuf, sync::LazyLock};
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+    sync::LazyLock,
+};
 mod lexer;
 
 static CLANG_FLAGS_WITH_ARGS: LazyLock<HashSet<&str>> = LazyLock::new(|| {
@@ -233,15 +237,37 @@ fn lex_linker_args<'a>(
     )
 }
 
-/// Process the clang arguments into PreparedArgs, separating compiler args and linker args, and also extracting build settings from the args.
+// File extensions that mark a positional argument as a link-stage input
+// (object files and libraries) rather than a compiler source.
+fn is_linker_input(path: &str) -> bool {
+    matches!(
+        Path::new(path).extension().and_then(|ext| ext.to_str()),
+        Some("o") | Some("obj") | Some("a") | Some("so") | Some("dll") | Some("dylib")
+    )
+}
+
+/// Result of splitting a clang command line: compiler-side pieces plus the
+/// ordered raw link-stage tokens (still to be re-lexed via `prepare_linker_args`).
+struct CompilerFlagResult {
+    compiler_args: Vec<String>,
+    compiler_inputs: Vec<PathBuf>,
+    // Link-stage tokens (from -Wl/-Xlinker/-z/-L/-l and positional inputs) in the
+    // order they appeared, so ordering-sensitive constructs like
+    // --whole-archive/--no-whole-archive brackets survive.
+    raw_link_tokens: Vec<String>,
+    output: Option<PathBuf>,
+}
+
+/// Process the clang arguments, separating compiler args from the ordered
+/// link-stage token stream, and also extracting build settings from the args.
 fn process_compiler_flags<'a>(
     flags: impl IntoIterator<Item = Flag<'a>>,
     build_settings: &mut BuildSettings,
     user_settings: &mut UserSettings,
-) -> Result<PreparedArgs> {
+) -> Result<CompilerFlagResult> {
     let mut compiler_flags = Vec::new();
-    let mut linker_args = Vec::new();
-    let mut inputs = Vec::new();
+    let mut raw_link_tokens = Vec::new();
+    let mut compiler_inputs = Vec::new();
     let mut output = None;
 
     for compiler_flag in flags {
@@ -249,11 +275,11 @@ fn process_compiler_flags<'a>(
             Flag::Simple(flag) | Flag::WithValue(flag, _, _)
                 if CLANG_FLAGS_TO_FORWARD_TO_WASM_LD.contains(flag) =>
             {
-                linker_args.extend(compiler_flag.to_args());
+                raw_link_tokens.extend(compiler_flag.to_args());
             }
             Flag::Simple(flag) if flag.starts_with("-Wl,") => {
                 for split in flag["-Wl,".len()..].split(',') {
-                    linker_args.push(split.to_owned());
+                    raw_link_tokens.push(split.to_owned());
                 }
             }
             Flag::Simple(arg) | Flag::WithValue(arg, _, _)
@@ -267,17 +293,22 @@ fn process_compiler_flags<'a>(
                 tracing::debug!("Discarding flag '{}'", &compiler_flag);
             }
             Flag::WithValue("-Xlinker", value, _) => {
-                linker_args.push(value.to_owned());
+                raw_link_tokens.push(value.to_owned());
             }
             Flag::WithValue("-z", value, _) => {
-                linker_args.push("-z".to_owned());
-                linker_args.push(value.to_owned());
+                raw_link_tokens.push("-z".to_owned());
+                raw_link_tokens.push(value.to_owned());
             }
             Flag::WithValue("-o", value, _) => {
                 output = Some(PathBuf::from(value));
             }
+            // Object/library inputs join the link stream in place so they keep
+            // their order relative to -Wl flags; other positionals are sources.
+            Flag::Positional(value) if is_linker_input(value) => {
+                raw_link_tokens.push(value.to_owned());
+            }
             Flag::Positional(value) => {
-                inputs.push(PathBuf::from(value));
+                compiler_inputs.push(PathBuf::from(value));
             }
             Flag::Terminator() => {
                 compiler_flags.push(compiler_flag);
@@ -293,34 +324,27 @@ fn process_compiler_flags<'a>(
         }
     }
 
-    let (linker_inputs, compiler_inputs) = inputs.into_iter().partition(|input| {
-        matches!(
-            input.extension().and_then(|ext| ext.to_str()),
-            Some("o") | Some("obj") | Some("a") | Some("so") | Some("dll") | Some("dylib")
-        )
-    });
-
     let compiler_args = compiler_flags
         .into_iter()
         .flat_map(|flag| flag.to_args().into_iter())
         .collect::<Vec<_>>();
 
-    Ok(PreparedArgs {
+    Ok(CompilerFlagResult {
         compiler_args,
-        linker_args,
         compiler_inputs,
-        linker_inputs,
+        raw_link_tokens,
         output,
     })
 }
 
 /// Process the wasm-ld arguments into PreparedArgs, extracting build settings from the args.
+/// The link-stage flags and inputs are kept in a single ordered stream so their
+/// original relative order (e.g. --whole-archive brackets) is preserved.
 fn process_linker_flags<'a>(
     flags: impl IntoIterator<Item = Flag<'a>>,
     user_settings: &mut UserSettings,
 ) -> Result<PreparedArgs> {
-    let mut linker_flags = Vec::new();
-    let mut inputs = Vec::new();
+    let mut link_args = Vec::new();
     let mut output = None;
 
     for linker_flag in flags {
@@ -335,33 +359,27 @@ fn process_linker_flags<'a>(
             Flag::WithValue("-o", value, _) => {
                 if user_settings.autoconf_workarounds && value == "conftest" {
                     user_settings.run_wasm_opt = Some(false);
-                    linker_flags.push(Flag::Simple("--no-shlib-sigcheck"));
+                    link_args.push(LinkToken::Flag("--no-shlib-sigcheck".to_owned()));
                 }
                 output = Some(PathBuf::from(value));
             }
             Flag::Positional(value) => {
-                inputs.push(PathBuf::from(value));
+                link_args.push(LinkToken::Input(PathBuf::from(value)));
             }
             Flag::Terminator() => {
-                linker_flags.push(linker_flag);
+                link_args.extend(linker_flag.to_args().into_iter().map(LinkToken::Flag));
             }
             Flag::Simple(_) | Flag::WithValue(_, _, _) => {
                 update_build_settings_from_linker_flag(&linker_flag, user_settings);
-                linker_flags.push(linker_flag);
+                link_args.extend(linker_flag.to_args().into_iter().map(LinkToken::Flag));
             }
         }
     }
 
-    let linker_args = linker_flags
-        .into_iter()
-        .flat_map(|flag| flag.to_args().into_iter())
-        .collect::<Vec<_>>();
-
     Ok(PreparedArgs {
         compiler_args: Vec::new(),
-        linker_args,
+        link_args,
         compiler_inputs: Vec::new(),
-        linker_inputs: inputs,
         output,
     })
 }
@@ -433,26 +451,35 @@ pub(super) fn prepare_compiler_args(
 
     let flags = lex_compiler_args(args.iter())?;
 
-    let mut result = process_compiler_flags(flags, &mut build_settings, user_settings)?;
+    let CompilerFlagResult {
+        compiler_args,
+        compiler_inputs,
+        mut raw_link_tokens,
+        output,
+    } = process_compiler_flags(flags, &mut build_settings, user_settings)?;
 
     if user_settings.autoconf_workarounds
-        && (result.compiler_inputs.contains(&"conftest.c".into())
-            || result.compiler_inputs.contains(&"conftest.cpp".into())
-            || result.output == Some("conftest".into()))
+        && (compiler_inputs.contains(&"conftest.c".into())
+            || compiler_inputs.contains(&"conftest.cpp".into())
+            || output == Some("conftest".into()))
     {
         // wasm opt fails if signature mismatches produce an invalid module
         user_settings.run_wasm_opt = Some(false);
         // Pass the flag to the linker to avoid shlib signature checks
-        result.linker_args.push("--no-shlib-sigcheck".to_owned());
+        raw_link_tokens.push("--no-shlib-sigcheck".to_owned());
     }
 
-    let linker_result = prepare_linker_args(result.linker_args, user_settings)?;
+    // Re-lex the raw link tokens through the wasm-ld path so -Wl/-Xlinker flags
+    // are correctly classified (flags vs inputs) and filtered, while their order
+    // is preserved by the single ordered stream.
+    let linker_result = prepare_linker_args(raw_link_tokens, user_settings)?;
 
-    result.linker_args = linker_result.linker_args;
-    result.linker_inputs.extend(linker_result.linker_inputs);
-    if result.output.is_none() {
-        result.output = linker_result.output;
-    }
+    let result = PreparedArgs {
+        compiler_args,
+        link_args: linker_result.link_args,
+        compiler_inputs,
+        output: output.or(linker_result.output),
+    };
 
     if user_settings.module_kind().requires_pic() {
         user_settings.pic = true;
@@ -567,12 +594,12 @@ mod tests {
         assert_eq!(bs.opt_level, OptLevel::O2);
         // -fwasm-exceptions side-effect should still take effect even though the flag is discarded
         assert_eq!(us.wasm_exceptions, WasmExceptionStyle::Exnref);
-        assert!(pa.linker_args.is_empty());
+        assert!(pa.linker_flags().is_empty());
         assert_eq!(
             pa.compiler_inputs,
             vec![PathBuf::from("not_discarded.c"), PathBuf::from("in.c")]
         );
-        assert!(pa.linker_inputs.is_empty());
+        assert!(pa.linker_inputs().is_empty());
     }
 
     #[test]
@@ -586,11 +613,11 @@ mod tests {
         ];
         let (pa, _) = prepare_compiler_args(args, &mut us, false).unwrap();
         assert_eq!(
-            pa.linker_args,
+            pa.linker_flags(),
             vec!["-lmylib".to_string(), "-l".to_string(), "mylib".to_string(),]
         );
         assert_eq!(pa.compiler_inputs, vec![PathBuf::from("in.c")]);
-        assert!(pa.linker_inputs.is_empty());
+        assert!(pa.linker_inputs().is_empty());
     }
 
     #[test]
@@ -604,10 +631,10 @@ mod tests {
         ];
         let pa = prepare_linker_args(args, &mut us).unwrap();
         assert_eq!(
-            pa.linker_args,
+            pa.linker_flags(),
             vec!["-lmylib".to_string(), "-l".to_string(), "mylib".to_string(),]
         );
-        assert_eq!(pa.linker_inputs, vec![PathBuf::from("input.o")]);
+        assert_eq!(pa.linker_inputs(), vec![PathBuf::from("input.o")]);
     }
 
     #[test]
@@ -644,17 +671,66 @@ mod tests {
             ]
         );
         assert_eq!(
-            pa.linker_args,
+            pa.linker_flags(),
             vec!["-foo".to_string(), "-z".to_string(), "zo".to_string()]
         );
         assert_eq!(pa.output, Some(PathBuf::from("out")));
         assert_eq!(pa.compiler_inputs, vec![PathBuf::from("in.c")]);
+        // Inputs keep their original command-line order: `bar` (from -Wl,-foo,bar)
+        // and `baz` (from -Xlinker baz) precede the trailing positional `lib.o`.
         assert_eq!(
-            pa.linker_inputs,
+            pa.linker_inputs(),
             vec![
-                PathBuf::from("lib.o"),
                 PathBuf::from("bar"),
                 PathBuf::from("baz"),
+                PathBuf::from("lib.o"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_whole_archive_bracket_order_preserved() {
+        // Regression: -Wl,--whole-archive <archive> -Wl,--no-whole-archive must
+        // reach wasm-ld with the archive still bracketed between the two markers.
+        let mut us = UserSettings::default();
+        let args = vec![
+            "-Wl,--whole-archive".to_string(),
+            "foo.a".to_string(),
+            "-Wl,--no-whole-archive".to_string(),
+        ];
+        let (pa, _) = prepare_compiler_args(args, &mut us, false).unwrap();
+
+        let stream = pa.link_stream();
+        let wa = stream.iter().position(|t| t == "--whole-archive").unwrap();
+        let archive = stream.iter().position(|t| t == "foo.a").unwrap();
+        let nwa = stream
+            .iter()
+            .position(|t| t == "--no-whole-archive")
+            .unwrap();
+        assert!(
+            wa < archive && archive < nwa,
+            "expected --whole-archive < foo.a < --no-whole-archive, got {stream:?}"
+        );
+        // And they must be contiguous: nothing injected between the markers.
+        assert_eq!(
+            &stream[wa..=nwa],
+            &["--whole-archive", "foo.a", "--no-whole-archive"]
+        );
+    }
+
+    #[test]
+    fn test_whole_archive_bracket_order_preserved_single_wl() {
+        // The same, but with all three tokens packed into one -Wl group, which
+        // is re-lexed and must still keep the archive between the markers.
+        let mut us = UserSettings::default();
+        let args = vec!["-Wl,--whole-archive,foo.a,--no-whole-archive".to_string()];
+        let (pa, _) = prepare_compiler_args(args, &mut us, false).unwrap();
+        assert_eq!(
+            pa.link_stream(),
+            vec![
+                "--whole-archive".to_string(),
+                "foo.a".to_string(),
+                "--no-whole-archive".to_string(),
             ]
         );
     }
@@ -673,14 +749,14 @@ mod tests {
         let pa = prepare_linker_args(args, &mut us).unwrap();
         assert_eq!(pa.output, Some(PathBuf::from("out.wasm")));
         assert_eq!(
-            pa.linker_args,
+            pa.linker_flags(),
             vec![
                 "-shared".to_string(),
                 "-m".to_string(),
                 "module".to_string()
             ]
         );
-        assert_eq!(pa.linker_inputs, vec![PathBuf::from("mod.wasm")]);
+        assert_eq!(pa.linker_inputs(), vec![PathBuf::from("mod.wasm")]);
         assert_eq!(us.module_kind, Some(ModuleKind::SharedLibrary));
     }
 
@@ -700,7 +776,7 @@ mod tests {
         // Should have disabled wasm-opt
         assert_eq!(us.run_wasm_opt, Some(false));
         // Should have added --no-shlib-sigcheck
-        assert_eq!(pa.linker_args, vec!["--no-shlib-sigcheck".to_string()]);
+        assert_eq!(pa.linker_flags(), vec!["--no-shlib-sigcheck".to_string()]);
     }
 
     #[test]
@@ -746,7 +822,7 @@ mod tests {
         let (pa, _) = prepare_compiler_args(args, &mut us, false).unwrap();
 
         // Only -L should be forwarded, all discard flags should be filtered out
-        assert_eq!(pa.linker_args, vec!["-L/some/path".to_string()]);
+        assert_eq!(pa.linker_flags(), vec!["-L/some/path".to_string()]);
     }
 
     #[test]
@@ -768,7 +844,7 @@ mod tests {
 
         // Only -L should be forwarded, all discard flags should be filtered out
         assert_eq!(
-            pa.linker_args,
+            pa.linker_flags(),
             vec![
                 "-L/some/path/a".to_string(),
                 "-L/some/path/b".to_string(),
@@ -790,7 +866,7 @@ mod tests {
         let (pa, _) = prepare_compiler_args(args, &mut us, false).unwrap();
 
         assert_eq!(
-            pa.linker_args,
+            pa.linker_flags(),
             vec!["--start-group".to_string(), "-L/some/path".to_string()]
         );
     }
@@ -815,7 +891,7 @@ mod tests {
         let (pa, _) = prepare_compiler_args(args, &mut us, false).unwrap();
 
         // Only -L should be forwarded, all discard flags should be filtered out
-        assert_eq!(pa.linker_args, vec!["-L/some/path".to_string()]);
+        assert_eq!(pa.linker_flags(), vec!["-L/some/path".to_string()]);
     }
 
     #[test]
@@ -842,7 +918,7 @@ mod tests {
         let (pa, _) = prepare_compiler_args(args, &mut us, false).unwrap();
 
         // Only -L should be forwarded, all discard flags (including their arguments) should be filtered out
-        assert_eq!(pa.linker_args, vec!["-L/some/path".to_string()]);
+        assert_eq!(pa.linker_flags(), vec!["-L/some/path".to_string()]);
     }
 
     #[test]
@@ -885,8 +961,8 @@ mod tests {
         ];
         let pa = prepare_linker_args(args, &mut us).unwrap();
 
-        assert_eq!(pa.linker_args, vec!["-L/some/path".to_string()]);
+        assert_eq!(pa.linker_flags(), vec!["-L/some/path".to_string()]);
         assert_eq!(pa.output, Some(PathBuf::from("output.wasm")));
-        assert_eq!(pa.linker_inputs, vec![PathBuf::from("input.o")]);
+        assert_eq!(pa.linker_inputs(), vec![PathBuf::from("input.o")]);
     }
 }


### PR DESCRIPTION
Right now, link inputs and link args get split apart and then appended after one-another.

This means that for order-sensitive args like `--whole-archive libfoobar.a --no-whole-archive`, it instead emits `--whole-archive --no-whole-archive libfoobar.a`, which means `libfoobar` gets dropped silently instead.

This PR makes it preserve ordering, as well as factoring out the argument building logic in order to make it testable.