### PR TITLE
Fix installer pointing at an unpublished release (WAX-605)

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,19 +1,38 @@
 name: Deploy Website
 
 on:
+  # Website-only changes (landing page, server) ship as soon as they land.
+  # install.sh is deliberately excluded: it pins a release version, so
+  # deploying it on merge advertises a release that does not exist yet. It
+  # goes out via the workflow_run trigger below instead (WAX-605).
   push:
     branches:
       - main
     paths:
       - 'installer/**'
+      - '!installer/public/install.sh'
+  # A finished Release means the version install.sh pins is now downloadable.
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
   workflow_dispatch:
 
 jobs:
   deploy-website:
     runs-on: ubuntu-latest
+    # Only deploy for a release that actually succeeded. Release also runs on
+    # pull_request (version checks only, no publish), so ignore those.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # For a release, deploy the installer as of the tagged commit rather
+          # than whatever main has drifted to since.
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref }}
       - name: Setup Wasmer
         uses: wasmerio/setup-wasmer@v3.1
       - name: Publish website

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,6 +187,10 @@ jobs:
         with:
           files: |
             wasixcc-*.tar.gz
-          draft: true
+          # Must NOT be a draft: draft assets 404 for anonymous downloads, and
+          # the installer on wasix.cc pins this exact version (see WAX-605).
+          # Everything gating this job (version consistency, build, crates.io
+          # publish) has already passed by the time we get here.
+          draft: false
           prerelease: false
           generate_release_notes: true

--- a/installer/public/install.sh
+++ b/installer/public/install.sh
@@ -102,21 +102,37 @@ download_wasixcc() {
 
     log "Fetching the latest wasixcc executable"
 
+    URL="https://github.com/wasix-org/wasixcc/releases/download/v$VERSION/wasixcc-$TARGET.tar.gz"
+    ARCHIVE="wasixcc-$TARGET.tar.gz"
+
     mkdir -p "$WASIXCC_DIR"
     cd "$WASIXCC_DIR"
+
+    # Download to a file rather than piping into tar. On an HTTP error the body
+    # ("Not Found") would otherwise be fed to tar, which reports the misleading
+    # "Unrecognized archive format" and buries the real cause (WAX-605).
+    rm -f "$ARCHIVE"
     if test -n "$CURL" ; then
         if test -n "$GITHUB_TOKEN" ; then
-            "$CURL" -H "authorization: Bearer $GITHUB_TOKEN" -L "https://github.com/wasix-org/wasixcc/releases/download/v$VERSION/wasixcc-$TARGET.tar.gz" --output - | "$TAR" -xz
+            "$CURL" -fL -H "authorization: Bearer $GITHUB_TOKEN" "$URL" --output "$ARCHIVE" \
+                || fail "Failed to download $URL"
         else
-            "$CURL" -L "https://github.com/wasix-org/wasixcc/releases/download/v$VERSION/wasixcc-$TARGET.tar.gz" --output - | "$TAR" -xz
+            "$CURL" -fL "$URL" --output "$ARCHIVE" \
+                || fail "Failed to download $URL"
         fi
     else
         if test -n "$GITHUB_TOKEN" ; then
-            "$WGET" --header "authorization: Bearer $GITHUB_TOKEN" -q -c "https://github.com/wasix-org/wasixcc/releases/download/v$VERSION/wasixcc-$TARGET.tar.gz" -O - | "$TAR" -xz
+            "$WGET" --header "authorization: Bearer $GITHUB_TOKEN" -q "$URL" -O "$ARCHIVE" \
+                || fail "Failed to download $URL"
         else
-            "$WGET" -q -c "https://github.com/wasix-org/wasixcc/releases/download/v$VERSION/wasixcc-$TARGET.tar.gz" -O - | "$TAR" -xz
+            "$WGET" -q "$URL" -O "$ARCHIVE" \
+                || fail "Failed to download $URL"
         fi
     fi
+
+    "$TAR" -xzf "$ARCHIVE" || fail "Failed to extract $ARCHIVE"
+    rm -f "$ARCHIVE"
+
     cd - > /dev/null 2>&1
 
     if test ! -f "$WASIXCC_EXECUTABLE" ; then


### PR DESCRIPTION
Fixes [WAX-605](https://linear.app/wasmer/issue/WAX-605/wasixcc-install-script-is-broken).

## What was broken

`curl -fsSL https://wasix.cc | sh` failed with `tar: Error opening archive: Unrecognized archive format`.

wasix.cc served an `install.sh` pinned to `VERSION="0.4.5"`, but the v0.4.5 GitHub release was still a **draft**. Draft release assets 404 for anonymous downloads, so the asset URL returned the 9-byte body `Not Found` — matching the `100 9 100 9` in the report. `curl -L` without `-f` piped those 9 bytes straight into `tar`, which blamed the archive format instead of the 404.

The release itself built fine and published to crates.io, which is why `cargo install wasixcc` worked as a workaround.

The draft has since been published manually, so installs work again. This PR stops it recurring.

## Changes

**`release.yml` — stop creating draft releases.** `draft: true` meant every release needed a manual "Publish release" click; 0.4.4 got one, 0.4.5 did not. Everything gating that job (version consistency, build, crates.io publish) has already passed by the time the release is cut, so the draft state bought nothing and silently broke the installer.

**`install.sh` — fail loudly on HTTP errors.** Downloads to a file with `curl -fL` / `wget` and checks the exit status before extracting, instead of piping the response into `tar`. A missing asset now says:

```
curl: (22) The requested URL returned error: 404
Error: Failed to download https://github.com/.../v9.9.9/wasixcc-x86_64-unknown-linux-gnu.tar.gz
```

**`deploy-website.yml` — stop deploying install.sh ahead of the release.** The website deployed on any push to `main` touching `installer/**`, so it went live pinning 0.4.5 **37 seconds before the release workflow even started** (`11:58:17Z` vs `11:58:54Z`). That window existed on every release, draft or not. `install.sh` is now excluded from the push trigger and ships via `workflow_run` once Release succeeds; other installer changes (landing page, `server.py`) still deploy immediately, and `workflow_dispatch` remains as a manual escape hatch.

## Testing

Ran the real `download_wasixcc` against an isolated `$HOME`:

| Case | Result |
|---|---|
| v0.4.5, curl | exits 0, extracts `wasixccenv`, `--version` reports `wasixcc 0.4.5`, no leftover tarball |
| v9.9.9, curl | exits 1, `Error: Failed to download <url>` |
| v9.9.9, wget | exits 1, `Error: Failed to download <url>` |

Also confirmed `sh -n install.sh` passes and both workflow YAMLs parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)